### PR TITLE
caching github api client

### DIFF
--- a/github.js
+++ b/github.js
@@ -1,0 +1,73 @@
+var github = (function() {
+
+	var api = 'https://api.github.com/';
+
+	var xhrOpen = XMLHttpRequest.prototype.open;
+	XMLHttpRequest.prototype.open = function (method, url) {
+		this.reqUrl = url;
+		return xhrOpen.apply(this, arguments);
+	};
+
+	var cache = {
+		get: function(key) {
+			var result = null;
+			if( typeof window.localStorage !== 'undefined' )  {
+				result = window.localStorage.getItem(key);
+			}
+			return result;
+		},
+		set: function(key, value) {
+			if( typeof window.localStorage !== 'undefined' )  {
+				window.localStorage.setItem(key, value);
+			}
+		},
+		getETag: function(url) {
+			return this.get(url + '::etag');
+		},
+		setEtag: function(req) {
+			return this.set(req.reqUrl + '::etag', req.getResponseHeader('ETag'));
+		},
+		getContent: function(url) {
+			return this.get(url + '::content');
+		},
+		setContent: function(req) {
+			return this.set(req.reqUrl + '::content', req.response);
+		}
+	};
+
+	var handleResponse = function(req, success) {
+		if( req.status === 304 && req.response.length === 0 ) {
+			success(JSON.parse(cache.getContent(req.reqUrl)));
+		} else if( req.status === 200 ) {
+			cache.setEtag(req);
+			cache.setContent(req);
+			success(JSON.parse(req.response));
+		} else {
+			success(JSON.parse(req.response));
+		}
+	};
+
+	return {
+		get: function(entity, id, success) {
+			var url = api + entity + '/' + id;
+			var etag = cache.getETag(url);
+			var req = new XMLHttpRequest();
+
+			req.onload = success;
+			req.open("get", url, true);
+			if( etag !== null ) { req.setRequestHeader('If-None-Match', etag); }
+			req.send();
+			return req;
+		},
+		getUser: function(user, success) {
+			var req = this.get('users', user, function() {
+				handleResponse(req, success);
+			});
+		},
+		getRepo: function(repo, success) {
+			var req = this.get('repos', repo, function() {
+				handleResponse(req, success);
+			});
+		}
+	};
+}());

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 		<script type="text/javascript" src="coders.js"></script>
 		<script type="text/javascript" src="code.js"></script>
 		<script type="text/javascript" src="code-nights.js"></script>
+		<script type="text/javascript" src="github.js"></script>
 
 		<style>
 			body{ margin: 0; display: flex; flex-direction: column; font-family: monospace;}
@@ -55,10 +56,7 @@
 					}
 				},
 				componentDidMount: function(){
-					this.req = new XMLHttpRequest();
-					this.req.onload = this._showAvatar;
-					this.req.open("get", "https://api.github.com/users/"+this.props.user, true);
-					this.req.send();
+					github.getUser(this.props.user, this._showAvatar);
 				},
 				render: function(){
 					return <div className="column-item">
@@ -72,8 +70,7 @@
 						</span>
 					</div>
 				},
-				_showAvatar: function(e){
-					var data = JSON.parse(this.req.response);
+				_showAvatar: function(data){
 					this.setState({avatar: data['avatar_url'], github: data['html_url']});
 				}
 			});
@@ -101,10 +98,7 @@
 					}
 				},
 				componentDidMount: function(){
-					this.req = new XMLHttpRequest();
-					this.req.onload = this._showAvatar;
-					this.req.open("get", "https://api.github.com/repos/"+this.props.repo, true);
-					this.req.send();
+					github.getRepo(this.props.repo, this._showAvatar);
 				},
 				render: function(){
 					return <div className="column-item">
@@ -118,8 +112,7 @@
 						</span>
 					</div>
 				},
-				_showAvatar: function(e){
-					var data = JSON.parse(this.req.response);
+				_showAvatar: function(data){
 					this.setState({desc: data['description'], url: data['html_url'], full_name: data['full_name']});
 				}
 			});
@@ -136,7 +129,7 @@
 				document.getElementById('code-column')
 			);
 
-						/* Repos */
+						/* Issues */
 			var GithubIssue = React.createClass({
 				req: null,
 				getInitialState: function(){
@@ -147,10 +140,7 @@
 					}
 				},
 				componentDidMount: function(){
-					this.req = new XMLHttpRequest();
-					this.req.onload = this._showAvatar;
-					this.req.open("get", "https://api.github.com/repos/"+this.props.issue, true);
-					this.req.send();
+					github.getRepo(this.props.issue, this._showAvatar);
 				},
 				render: function(){
 					return <div className="column-item">
@@ -164,8 +154,7 @@
 						</span>
 					</div>
 				},
-				_showAvatar: function(e){
-					var data = JSON.parse(this.req.response);
+				_showAvatar: function(data){
 					this.setState({title: data['title'], url: data['html_url'], comments: data['comments']});
 				}
 			});


### PR DESCRIPTION
Alleviates some of the pain associated with #4. It could be improved by only caching those details details which are used, rather than the entire json response. There's still circumstances under which the api rate limit will be hit. Though, this should ensure they are rarer.

unfortunately, runs up against a [firefex bug](https://bugzilla.mozilla.org/show_bug.cgi?id=884693). I think it's just extra messages in the console. Doesn't appear to break anything.

